### PR TITLE
Fix segmentation output numbering with zero-padding

### DIFF
--- a/Granny/Analyses/Segmentation.py
+++ b/Granny/Analyses/Segmentation.py
@@ -375,7 +375,7 @@ class Segmentation(Analysis):
             for channel in range(3):
                 individual_image[:, :, channel] = tray_image_array[y1:y2, x1:x2, channel] * mask[y1:y2, x1:x2]  # type: ignore
             image_name = (
-                pathlib.Path(tray_image.getImageName()).stem + f"_tray_info_{i+1}" + ".png"
+                pathlib.Path(tray_image.getImageName()).stem + f"_tray_info_{i+1:02d}" + ".png"
             )
             image_instance: Image = RGBImage(image_name)
             image_instance.setImage(individual_image)
@@ -430,7 +430,7 @@ class Segmentation(Analysis):
             mask = sorted_masks[i]
             for channel in range(3):
                 individual_image[:, :, channel] = tray_image_array[y1:y2, x1:x2, channel] * mask[y1:y2, x1:x2]  # type: ignore
-            image_name = pathlib.Path(tray_image.getImageName()).stem + f"_fruit_{i+1}" + ".png"
+            image_name = pathlib.Path(tray_image.getImageName()).stem + f"_fruit_{i+1:02d}" + ".png"
             image_instance: Image = RGBImage(image_name)
             image_instance.setImage(individual_image)
             individual_images.append(image_instance)


### PR DESCRIPTION
Add zero-padding to fruit and tray_info image filenames to ensure proper lexicographic sorting. Changes _fruit_1, _fruit_10 to _fruit_01, _fruit_10 format, fixing CSV ordering and file listing issues.