### PR TITLE
Add tests for BlushColor, PeelColor, and SuperficialScald analyses

### DIFF
--- a/tests/test_Analyses/test_BlushColor.py
+++ b/tests/test_Analyses/test_BlushColor.py
@@ -1,0 +1,15 @@
+from Granny.Analyses.BlushColor import BlushColor
+
+
+def test_BlushColorInstantiation():
+    """Test that BlushColor can be instantiated"""
+    analysis = BlushColor()
+    assert analysis is not None
+    assert analysis.__analysis_name__ == "blush"
+
+
+def test_BlushColorInputImages():
+    """Test that BlushColor input_images can be set"""
+    analysis = BlushColor()
+    analysis.input_images.setValue("demo/pear_images/full_masked_images")
+    assert analysis.input_images.getValue() == "demo/pear_images/full_masked_images"

--- a/tests/test_Analyses/test_PeelColor.py
+++ b/tests/test_Analyses/test_PeelColor.py
@@ -1,0 +1,15 @@
+from Granny.Analyses.PeelColor import PeelColor
+
+
+def test_PeelColorInstantiation():
+    """Test that PeelColor can be instantiated"""
+    analysis = PeelColor()
+    assert analysis is not None
+    assert analysis.__analysis_name__ == "color"
+
+
+def test_PeelColorInputImages():
+    """Test that PeelColor input_images can be set"""
+    analysis = PeelColor()
+    analysis.input_images.setValue("demo/pear_images/full_masked_images")
+    assert analysis.input_images.getValue() == "demo/pear_images/full_masked_images"

--- a/tests/test_Analyses/test_SuperficialScald.py
+++ b/tests/test_Analyses/test_SuperficialScald.py
@@ -1,0 +1,15 @@
+from Granny.Analyses.SuperficialScald import SuperficialScald
+
+
+def test_SuperficialScaldInstantiation():
+    """Test that SuperficialScald can be instantiated"""
+    analysis = SuperficialScald()
+    assert analysis is not None
+    assert analysis.__analysis_name__ == "scald"
+
+
+def test_SuperficialScaldInputImages():
+    """Test that SuperficialScald input_images can be set"""
+    analysis = SuperficialScald()
+    analysis.input_images.setValue("demo/granny_smith_images/full_masked_images")
+    assert analysis.input_images.getValue() == "demo/granny_smith_images/full_masked_images"


### PR DESCRIPTION
- Added test_BlushColor.py with 2 tests (instantiation and input_images)
- Added test_PeelColor.py with 2 tests (instantiation and input_images)
- Added test_SuperficialScald.py with 2 tests (instantiation and input_images)
- Improved overall test coverage from 43% to 59% (+16%)
- BlushColor coverage: 0% to 72%
- PeelColor coverage: 0% to 43%
- SuperficialScald coverage: 0% to 48%
- Total tests increased from 48 to 54