### PR TITLE
Fix FileDirValue to validate input before setting value

### DIFF
--- a/Granny/Models/Values/FileDirValue.py
+++ b/Granny/Models/Values/FileDirValue.py
@@ -25,10 +25,20 @@ class FileDirValue(Value):
         Raises:
         ValueError: If the path is not a valid directory after assignment.
         """
-        self.value = value
-        if not self.validate():
+        # Validate input before setting
+        if not isinstance(value, str):
+            raise ValueError(f"Directory path must be a string, got {type(value)}")
+        if not value.strip():
+            raise ValueError("Directory path cannot be empty")
+        
+        # Create directory first, then set and validate
+        os.makedirs(value, exist_ok=True)
+        
+        # Only set the value after successful directory creation and validation
+        if os.path.isdir(value):
+            self.value = value
+        else:
             raise ValueError("Not a directory. Please specify a directory.")
-        os.makedirs(self.value, exist_ok=True)
 
     def validate(self) -> bool:
         """


### PR DESCRIPTION
- Add input validation before assigning to self.value
- Validate that input is a string and not empty
- Only set self.value after successful directory creation and validation
- Addresses requirement to validate all values before they get set