### PR TITLE
Increase default segmentation confidence threshold to 0.7

### DIFF
--- a/Granny/Analyses/Segmentation.py
+++ b/Granny/Analyses/Segmentation.py
@@ -142,7 +142,7 @@ class Segmentation(Analysis):
         )
         self.conf_threshold.setMin(0.0)
         self.conf_threshold.setMax(1.0)
-        self.conf_threshold.setValue(0.25)
+        self.conf_threshold.setValue(0.7)
         self.conf_threshold.setIsRequired(False)
 
         # YOLO IOU threshold parameter


### PR DESCRIPTION
Raises the default YOLO confidence threshold from 0.25 to 0.7 to reduce false positive detections during segmentation.